### PR TITLE
Dodanie możliwości parametryzowania trybu graficznego

### DIFF
--- a/2D-Game/Engine.cpp
+++ b/2D-Game/Engine.cpp
@@ -1,7 +1,7 @@
 #include "Engine.h"
 
 Engine::Engine() {
-	this->initWindow();
+	this->initWindow(WINDOWED);
 	this->initPlayer();
 }
 
@@ -31,12 +31,24 @@ void Engine::run() {
 
 
 //Private functions
-void Engine::initWindow() {
+void Engine::initWindow(int windowMode) {
 	Vector2f resolution;
 
 	resolution.x = VideoMode::getDesktopMode().width;
 	resolution.y = VideoMode::getDesktopMode().height;
-	this->window = new RenderWindow(VideoMode(resolution.x, resolution.y), "2D Platform Game", Style::Close);
+
+	switch (windowMode) {
+	case FULLSCREEN:
+		this->window = new RenderWindow(VideoMode(resolution.x, resolution.y), "2D Platform Game", Style::Fullscreen);
+		break;
+	case WINDOWED:
+		this->window = new RenderWindow(VideoMode(resolution.x, resolution.y), "2D Platform Game", Style::Close);
+		break;
+	case CUSTOM:
+		this->window = new RenderWindow(VideoMode(CUSTOM_RESOLUTION_X, CUSTOM_RESOLUTION_Y), "2D Platform Game", Style::Close);
+		break;
+	}
+
 	this->window->setVerticalSyncEnabled(true);
 }
 

--- a/2D-Game/Engine.h
+++ b/2D-Game/Engine.h
@@ -3,7 +3,12 @@
 #include "Player.h"
 #include "PrimitiveRender.h"
 
+#define CUSTOM_RESOLUTION_X 1280
+#define CUSTOM_RESOLUTION_Y 720
+
 using namespace sf;
+
+enum WindowMode {FULLSCREEN, WINDOWED, CUSTOM};
 
 class Engine {
 
@@ -25,7 +30,7 @@ private:
 	PrimitiveRender primitiveRender;
 
 	//Private functions
-	void initWindow();
+	void initWindow(int windowMode);
 	void initPlayer();
 
 	void update();

--- a/2D-Game/Player.cpp
+++ b/2D-Game/Player.cpp
@@ -34,7 +34,7 @@ void Player::render(sf::RenderTarget& target) {
 
 void Player::initTexture() {
 	//Load texture from file
-	if (!this->texture.loadFromFile("Textures/character.png")) {
+	if (!this->texture.loadFromFile("./Textures/character.png")) {
 		std::cout << "ERROR::PLAYER::LOAD_TEXTURE::Could not find the texture file!" << std::endl;
 	}
 }


### PR DESCRIPTION
Dodałem możliwość otwarcia okna w 3 trybach. Żeby wybrać tryb trzeba przez parametr podać stałą (dodałem typ wyliczeniowy WindowMode zeby było łatwiej) do funkcji initWindow(). Jeżeli wybierzemy opcje CUSTOM to możemy dostosować rozdzielczość zmieniając 2 stałe w pliku engine.h: CUSTOM_RESOLUTION_X i CUSTOM_RESOLUTION_Y.